### PR TITLE
feature: ATA Device outdoor temperature

### DIFF
--- a/src/pymelcloud/ata_device.py
+++ b/src/pymelcloud/ata_device.py
@@ -208,6 +208,16 @@ class AtaDevice(Device):
         return self._state.get("RoomTemperature")
 
     @property
+    def outdoor_temperature(self) -> Optional[float]:
+        """Return outdoor temperature reported by the device."""
+        if self._device_conf.get("HideOutdoorTemperature", False):
+            return None
+        device = self._device_conf.get("Device", {})
+        if not device.get("HasOutdoorTemperature", False):
+            return None
+        return device.get("OutdoorTemperature")
+
+    @property
     def target_temperature(self) -> Optional[float]:
         """Return target temperature set for the device."""
         if self._state is None:


### PR DESCRIPTION
# Proposed Changes

Create a property which returns the outdoor temperature reported by the ATA (Air-to-Air) device.

The `HideOutdoorTemperature` and `HasOutdoorTemperature` properties are checked before returning the `OutdoorTemperature` property.