### PR TITLE
refactor/Refactor type hints to use built-in generic types and general formating

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,8 +81,10 @@ repos:
         name: 🆎 Static type checking using mypy
         language: system
         types: [python]
-        entry: poetry run mypy
+        entry: poetry run mypy --namespace-packages
         require_serial: true
+        pass_filenames: false
+        args: [src]
       - id: no-commit-to-branch
         name: 🛑 Don't commit to main branch
         language: system
@@ -107,7 +109,8 @@ repos:
         name: 🌟 Starring code with pylint
         language: system
         types: [python]
-        entry: poetry run pylint
+        entry: poetry run pylint src
+        pass_filenames: false
       - id: pytest
         name: 🧪 Running tests and test coverage with pytest
         language: system

--- a/.yamllint
+++ b/.yamllint
@@ -59,7 +59,7 @@ rules:
     level: error
   new-lines:
     level: error
-    type: unix
+    type: platform
   trailing-spaces:
     level: error
   truthy:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2360,4 +2360,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "de75aba34bf37aeed5755527a629c178db7bc5e6dc0505439ac223db3972afd4"
+content-hash = "5cda50ffac082e62ba7fd3048b0ba3572dcf9ff5c783069db5278e1a5e5aabf8"

--- a/pylintrc
+++ b/pylintrc
@@ -14,10 +14,8 @@ good-names=id,i,j,k,ex,Run,_,fp
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
-# redefined-variable-type - this is Python, we're duck typing!
 # too-many-* - are not enforced for the sake of readability
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
@@ -28,7 +26,6 @@ good-names=id,i,j,k,ex,Run,_,fp
 # wrong-import-order - isort guards this
 disable=
   format,
-  abstract-class-little-used,
   abstract-method,
   cyclic-import,
   duplicate-code,
@@ -37,7 +34,6 @@ disable=
   inconsistent-return-statements,
   locally-disabled,
   not-context-manager,
-  redefined-variable-type,
   too-few-public-methods,
   too-many-ancestors,
   too-many-arguments,
@@ -66,4 +62,4 @@ ignored-classes=_CountingAttr
 expected-line-ending-format=LF
 
 [EXCEPTIONS]
-overgeneral-exceptions=BaseException,Exception
+overgeneral-exceptions=builtins.BaseException,builtins.Exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,44 @@
-[tool.poetry]
+[project]
 name = "python-melcloud"
 version = "0.1.1"
-authors = ["Erwin Douna <e.douna@gmail.com>"]
+description = "Asynchronous Python client for controlling Melcloud devices."
+authors = [{ name = "Erwin Douna", email = "e.douna@gmail.com" }]
+maintainers = [{ name = "Erwin Douna", email = "e.douna@gmail.com" }]
+license = { text = "MIT" }
+readme = "README.md"
+keywords = ["melcloud", "homeassistant", "api", "async", "client"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: AsyncIO",
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-description = "Asynchronous Python client for controlling Melcloud devices."
-documentation = "https://github.com/erwindouna/python-melcloud"
-homepage = "https://github.com/erwindouna/python-melcloud"
-keywords = ["melcloud", "homeassistant", "api", "async", "client"]
-license = "MIT"
-maintainers = ["Erwin Douna <e.douna@gmail.com>"]
-packages = [{ include = "pymelcloud", from = "src" }]
-readme = "README.md"
-repository = "https://github.com/erwindouna/python-melcloud"
+requires-python = ">=3.12"
+dependencies = [
+  "aiohttp>=3.0.0",
+]
 
-[tool.poetry.dependencies]
-aiohttp = ">=3.0.0"
-python = "^3.12"
-
-[tool.poetry.urls]
+[project.urls]
+Homepage = "https://github.com/erwindouna/python-melcloud"
+Repository = "https://github.com/erwindouna/python-melcloud"
+Documentation = "https://github.com/erwindouna/python-melcloud"
 "Bug Tracker" = "https://github.com/erwindouna/python-melcloud/issues"
 Changelog = "https://github.com/erwindouna/python-melcloud/releases"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+packages = [{ include = "pymelcloud", from = "src" }]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+aiohttp = ">=3.0.0"
+
 
 [tool.poetry.group.dev.dependencies]
 aresponses = "3.0.0"
@@ -103,30 +115,10 @@ max-line-length = 88
 [tool.pytest.ini_options]
 addopts = "--cov --cov-fail-under=55" # Fice for now, since this is how the project was inherited
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
-ignore = [
-  "ANN401",  # Opinionated warning on disallowing dynamically typed expressions
-  "D203",    # Conflicts with other rules
-  "ARG002",  # Conflicts with other rules
-  "D213",    # Conflicts with other rules
-  "D417",    # False positives in some occasions
-  "PLR2004", # Just annoying, not really useful
-  "SLOT000", # Has a bug with enums: https://github.com/astral-sh/ruff/issues/5748
-  "TRY003",  # Avoid specifying long messages outside the exception class
-  "EM101",   # Exception must not use a string literal, assign to variable first
-  "EM102",   # Exception must not use an f-string literal, assign to variable first
-  "PLR0913", # Too many arguments in function definition
-  "N815",    # Scope should not be mixedCase
-  "PLR0912", # Too many branches
-  "PLR0915", # Too many statements
-  "C901",    # Too complex
-
-  # Conflicts with the Ruff formatter
-  "COM812",
-  "ISC001",
-]
-select = ["ALL"]
+target-version = "py312"
 
 [tool.ruff.lint]
 ignore = [
@@ -145,6 +137,7 @@ ignore = [
   "PLR0912", # Too many branches
   "PLR0915", # Too many statements
   "C901",    # Too complex
+  "S101",    # Use of assert detected (allow in tests)
 
   # Conflicts with the Ruff formatter
   "COM812",
@@ -161,7 +154,3 @@ known-first-party = ["pymelcloud"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 25
-
-[build-system]
-build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core>=1.5,<2.0"]

--- a/src/pymelcloud/__init__.py
+++ b/src/pymelcloud/__init__.py
@@ -1,45 +1,48 @@
 """MELCloud client library."""
+
 from datetime import timedelta
-from typing import Dict, List, Optional
 
 from aiohttp import ClientSession
 
 from pymelcloud.ata_device import AtaDevice
 from pymelcloud.atw_device import AtwDevice
-from pymelcloud.erv_device import ErvDevice
 from pymelcloud.client import Client as _Client
 from pymelcloud.client import login as _login
 from pymelcloud.const import DEVICE_TYPE_ATA, DEVICE_TYPE_ATW, DEVICE_TYPE_ERV
 from pymelcloud.device import Device
+from pymelcloud.erv_device import ErvDevice
 
 
 async def login(
-    email: str, password: str, session: Optional[ClientSession] = None,
+    email: str,
+    password: str,
+    session: ClientSession | None = None,
 ) -> str:
     """Log in to MELCloud with given credentials.
 
     Returns access token.
     """
-    _client = await _login(email, password, session,)
+    _client = await _login(email, password, session)
     return _client.token
 
 
 async def get_devices(
     token: str,
-    session: Optional[ClientSession] = None,
+    session: ClientSession | None = None,
     *,
-    conf_update_interval=timedelta(minutes=5),
-    device_set_debounce=timedelta(seconds=1),
-) -> Dict[str, List[Device]]:
+    conf_update_interval: timedelta = timedelta(minutes=5),
+    device_set_debounce: timedelta = timedelta(seconds=1),
+) -> dict[str, list[Device]]:
     """Initialize Devices available with the token.
 
     The devices share a the same Client instance and pool config fetches. The devices
     should be fetched only once during application life cycle to leverage the request
     pooling and rate limits.
 
-    Keyword arguments:
+    Keyword Arguments:
         conf_update_interval -- rate limit for fetching device confs. (default = 5 min)
         device_set_debounce -- debounce time for writing device state. (default = 1 s)
+
     """
     _client = _Client(
         token,

--- a/tests/test_atw_properties.py
+++ b/tests/test_atw_properties.py
@@ -1,7 +1,7 @@
 """Ecodan tests."""
+
 import pytest
 
-import src.pymelcloud
 from src.pymelcloud import DEVICE_TYPE_ATW
 from src.pymelcloud.atw_device import (
     OPERATION_MODE_AUTO,
@@ -19,6 +19,7 @@ from src.pymelcloud.atw_device import (
     ZONE_STATUS_UNKNOWN,
     AtwDevice,
 )
+
 from .util import build_device
 
 
@@ -28,7 +29,8 @@ def _build_device(device_conf_name: str, device_state_name: str) -> AtwDevice:
 
 
 @pytest.mark.asyncio
-async def test_1zone():
+async def test_1zone() -> None:
+    """Test ATW device with single zone configuration."""
     device = _build_device("atw_1zone_listdevice.json", "atw_1zone_get.json")
 
     assert device.name == "Heater and Water"
@@ -98,7 +100,8 @@ async def test_1zone():
 
 
 @pytest.mark.asyncio
-async def test_2zone():
+async def test_2zone() -> None:
+    """Test ATW device with dual zone configuration."""
     device = _build_device("atw_2zone_listdevice.json", "atw_2zone_get.json")
 
     assert device.name == "Home"
@@ -194,7 +197,8 @@ async def test_2zone():
 
 
 @pytest.mark.asyncio
-async def test_2zone_cancool():
+async def test_2zone_cancool() -> None:
+    """Test ATW device with dual zone configuration and cooling capability."""
     device = _build_device(
         "atw_2zone_cancool_listdevice.json", "atw_2zone_cancool_get.json"
     )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,22 +1,30 @@
 """Device tests."""
-from typing import Any, Dict, Optional
+
+from typing import Any
 
 import pytest
-from unittest.mock import AsyncMock, Mock, patch
+
 from src.pymelcloud.ata_device import AtaDevice
+
 from .util import build_device
 
-import src.pymelcloud  
 
-def _build_device(device_conf_name: str, device_state_name: str, energy_report: Optional[Dict[Any, Any]] = None) -> AtaDevice:
-    device_conf, client = build_device(device_conf_name, device_state_name, energy_report)
+def _build_device(
+    device_conf_name: str,
+    device_state_name: str,
+    energy_report: dict[Any, Any] | None = None,
+) -> AtaDevice:
+    device_conf, client = build_device(
+        device_conf_name, device_state_name, energy_report
+    )
     return AtaDevice(device_conf, client)
 
 
 @pytest.mark.asyncio
-async def test_round_temperature():
+async def test_round_temperature() -> None:
+    """Test temperature rounding functionality."""
     device = _build_device("ata_listdevice.json", "ata_get.json")
-    device._device_conf.get("Device")["TemperatureIncrement"] = 0.5
+    device._device_conf.setdefault("Device", {})["TemperatureIncrement"] = 0.5  # noqa: SLF001
 
     assert device.round_temperature(23.99999) == 24.0
     assert device.round_temperature(24.0) == 24.0
@@ -29,7 +37,7 @@ async def test_round_temperature():
     assert device.round_temperature(24.75) == 25.0
     assert device.round_temperature(24.75001) == 25.0
 
-    device._device_conf.get("Device")["TemperatureIncrement"] = 1
+    device._device_conf.setdefault("Device", {})["TemperatureIncrement"] = 1  # noqa: SLF001
 
     assert device.round_temperature(23.99999) == 24.0
     assert device.round_temperature(24.0) == 24.0
@@ -42,21 +50,27 @@ async def test_round_temperature():
     assert device.round_temperature(25.49999) == 25.0
     assert device.round_temperature(25.5) == 26.0
 
+
 @pytest.mark.asyncio
-async def test_energy_report_none_if_no_report():
+async def test_energy_report_none_if_no_report() -> None:
+    """Test energy report returns None when no report is available."""
     device = _build_device("ata_listdevice.json", "ata_get.json")
 
     await device.update()
 
     assert device.daily_energy_consumed is None
 
-def test_energy_report_before_update():
+
+def test_energy_report_before_update() -> None:
+    """Test energy report before device state update."""
     device = _build_device("ata_listdevice.json", "ata_get.json")
 
     assert device.daily_energy_consumed is None
 
+
 @pytest.mark.asyncio
-async def test_round_temperature():
+async def test_energy_report_with_report() -> None:
+    """Test energy report with actual report data."""
     device = _build_device(
         "ata_listdevice.json",
         "ata_get.json",

--- a/tests/test_erv_properties.py
+++ b/tests/test_erv_properties.py
@@ -1,11 +1,11 @@
 """ERV tests."""
-import json
-import os
 
-import pytest
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
-import src.pymelcloud
+import pytest
+
 from src.pymelcloud import DEVICE_TYPE_ERV
 from src.pymelcloud.erv_device import (
     VENTILATION_MODE_AUTO,
@@ -16,11 +16,13 @@ from src.pymelcloud.erv_device import (
 
 
 def _build_device(device_conf_name: str, device_state_name: str) -> ErvDevice:
-    test_dir = os.path.join(os.path.dirname(__file__), "samples")
-    with open(os.path.join(test_dir, device_conf_name), "r") as json_file:
+    test_dir = Path(__file__).parent / "samples"
+    device_conf_path = test_dir / device_conf_name
+    with device_conf_path.open() as json_file:
         device_conf = json.load(json_file)
 
-    with open(os.path.join(test_dir, device_state_name), "r") as json_file:
+    device_state_path = test_dir / device_state_name
+    with device_state_path.open() as json_file:
         device_state = json.load(json_file)
 
     with patch("src.pymelcloud.client.Client") as _client:
@@ -33,8 +35,10 @@ def _build_device(device_conf_name: str, device_state_name: str) -> ErvDevice:
 
     return ErvDevice(device_conf, client)
 
+
 @pytest.mark.asyncio
-async def test_erv():
+async def test_erv() -> None:
+    """Test ERV device properties."""
     device = _build_device("erv_listdevice.json", "erv_get.json")
 
     assert device.name == ""
@@ -80,4 +84,4 @@ async def test_erv():
     assert device.wifi_signal == -65
     assert device.has_error is False
     assert device.error_code == 8000
-    assert str(device.last_seen) == '2020-07-07 06:44:11.027000+00:00'
+    assert str(device.last_seen) == "2020-07-07 06:44:11.027000+00:00"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,58 @@
+"""Test module imports and basic functionality."""
+
+import pytest
+from aiohttp.client_exceptions import ClientResponseError
+
+import pymelcloud
+from pymelcloud import DEVICE_TYPE_ATA, DEVICE_TYPE_ATW, DEVICE_TYPE_ERV
+from pymelcloud.ata_device import AtaDevice
+from pymelcloud.atw_device import AtwDevice
+from pymelcloud.client import Client
+from pymelcloud.device import Device
+from pymelcloud.erv_device import ErvDevice
+
+
+def test_imports() -> None:
+    """Test that all imports work correctly."""
+    # Test constants are importable
+    assert DEVICE_TYPE_ATA == "ata"
+    assert DEVICE_TYPE_ATW == "atw"
+    assert DEVICE_TYPE_ERV == "erv"
+
+    # Test classes are importable
+    assert AtaDevice is not None
+    assert AtwDevice is not None
+    assert Client is not None
+    assert Device is not None
+    assert ErvDevice is not None
+
+
+def test_module_docstring() -> None:
+    """Test that the module has a docstring."""
+    assert pymelcloud.__doc__ == "MELCloud client library."
+
+
+@pytest.mark.asyncio
+async def test_login_function_exists() -> None:
+    """Test that login function exists and has correct signature."""
+    # Just test the function exists and is callable
+    assert callable(pymelcloud.login)
+
+    # Test it raises appropriate error with invalid credentials
+    with pytest.raises(
+        (ValueError, ConnectionError, RuntimeError, ClientResponseError)
+    ):
+        await pymelcloud.login("invalid", "credentials")
+
+
+@pytest.mark.asyncio
+async def test_get_devices_function_exists() -> None:
+    """Test that get_devices function exists and has correct signature."""
+    # Just test the function exists and is callable
+    assert callable(pymelcloud.get_devices)
+
+    # Test it raises appropriate error with invalid token
+    with pytest.raises(
+        (ValueError, ConnectionError, RuntimeError, ClientResponseError)
+    ):
+        await pymelcloud.get_devices("invalid_token")

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,20 +1,29 @@
-import json
-import os
-from typing import Any, Dict, Optional
+"""Test utilities for MELCloud device testing."""
 
+import json
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
-import src.pymelcloud  # Ensure the import reflects the new location
- 
-def build_device(device_conf_name: str, device_state_name: str, energy_report: Optional[Dict[Any, Any]]=None):
-    test_dir = os.path.join(os.path.dirname(__file__), "samples")
-    with open(os.path.join(test_dir, device_conf_name), "r") as json_file:
+
+def build_device(
+    device_conf_name: str,
+    device_state_name: str,
+    energy_report: dict[Any, Any] | None = None,
+) -> Any:
+    """Build a test device with mocked client and data from JSON files."""
+    test_dir = Path(__file__).parent / "samples"
+    device_conf_path = test_dir / device_conf_name
+    with device_conf_path.open() as json_file:
         device_conf = json.load(json_file)
 
-    with open(os.path.join(test_dir, device_state_name), "r") as json_file:
+    device_state_path = test_dir / device_state_name
+    with device_state_path.open() as json_file:
         device_state = json.load(json_file)
 
-    with patch("src.pymelcloud.client.Client") as _client:  # Ensure the patch path reflects the new location
+    with patch(
+        "src.pymelcloud.client.Client"
+    ) as _client:  # Ensure the patch path reflects the new location
         _client.update_confs = AsyncMock()
         _client.device_confs.__iter__ = Mock(return_value=[device_conf].__iter__())
         _client.fetch_device_units = AsyncMock(return_value=[])


### PR DESCRIPTION
**A lot of minor changes.** 
- Refactor type hints to use built-in generic types and general formating. 
- Fixed some configuration connected to pre-commit-config. 
- pyproject.toml now use new format instead of old
